### PR TITLE
added checkboxes in MemoryFrame and RegisterFrame to toggle between hexadecimal and decimal display of values

### DIFF
--- a/src/riscVivid/gui/Preference.java
+++ b/src/riscVivid/gui/Preference.java
@@ -46,16 +46,12 @@ public class Preference
 
     public static boolean displayMemoryAsHex()
     {
-        // TODO: Add GUI switch
-        // boolean isHex = pref.getBoolean(displayMemoryAsHex, true);
-        return true;
+        return pref.getBoolean(displayMemoryAsHex, true);
     }
 
     public static boolean displayRegistersAsHex()
     {
-        // TODO: Add GUI switch
-        // boolean isHex = pref.getBoolean(displayRegistersAsHex, true);
-        return true;
+        return pref.getBoolean(displayRegistersAsHex, true);
     }
 
     // TODO: Also move all configuration stuff into this file.

--- a/src/riscVivid/gui/internalframes/concreteframes/MemoryFrame.java
+++ b/src/riscVivid/gui/internalframes/concreteframes/MemoryFrame.java
@@ -21,14 +21,18 @@
 package riscVivid.gui.internalframes.concreteframes;
 
 import java.awt.BorderLayout;
+import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -50,12 +54,13 @@ import riscVivid.gui.internalframes.util.TableSizeCalculator;
 import riscVivid.gui.internalframes.util.ValueInput;
 
 @SuppressWarnings("serial")
-public final class MemoryFrame extends OpenDLXSimInternalFrame implements ActionListener, KeyListener, FocusListener
+public final class MemoryFrame extends OpenDLXSimInternalFrame implements ActionListener, KeyListener, FocusListener, ItemListener
 {
 
     //tables, scrollpane and table models
     private JTable memoryTable;
     private JButton reload;
+	private JCheckBox checkBoxHex;
     private static int rows = 100, startAddr = 0;
     private JTextField rowInput;
     private JTextField addrInput;
@@ -131,10 +136,18 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
         inputPanel.add(rowInput);
         add(inputPanel, BorderLayout.NORTH);
         //controls
-        JPanel controlPanel = new JPanel();
+        JPanel controlPanel = new JPanel(new GridLayout(1, 2));
         reload = new JButton("reload");
         reload.addActionListener(this);
-        controlPanel.add(reload);
+        JPanel reloadPanel = new JPanel();
+      	reloadPanel.add(reload);
+      	controlPanel.add(reloadPanel);
+        checkBoxHex = new JCheckBox("values as hex");
+		checkBoxHex.setSelected(Preference.displayMemoryAsHex());
+		checkBoxHex.addItemListener(this);
+		JPanel checkBoxPanel = new JPanel();
+		checkBoxPanel.add(checkBoxHex);
+		controlPanel.add(checkBoxPanel);
         add(controlPanel, BorderLayout.SOUTH);
         pack();
         setVisible(true);
@@ -215,5 +228,11 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
     public void focusLost(FocusEvent e)
     {
     }
+    
+	@Override
+	public void itemStateChanged(ItemEvent e) {
+		Preference.pref.putBoolean(Preference.displayMemoryAsHex, checkBoxHex.isSelected());
+		update();
+	}
 
 }

--- a/src/riscVivid/gui/internalframes/concreteframes/RegisterFrame.java
+++ b/src/riscVivid/gui/internalframes/concreteframes/RegisterFrame.java
@@ -21,9 +21,13 @@
 package riscVivid.gui.internalframes.concreteframes;
 
 import java.awt.BorderLayout;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
 
 import riscVivid.RegisterSet;
 import riscVivid.datatypes.ArchCfg;
@@ -36,11 +40,12 @@ import riscVivid.gui.internalframes.factories.tableFactories.RegisterTableFactor
 import riscVivid.gui.internalframes.util.TableSizeCalculator;
 
 @SuppressWarnings("serial")
-public final class RegisterFrame extends OpenDLXSimInternalFrame
+public final class RegisterFrame extends OpenDLXSimInternalFrame implements ItemListener
 {
 
     private RegisterSet rs;
     private JTable registerTable;
+    private JCheckBox checkBoxHex;
 
     public RegisterFrame(String title)
     {
@@ -79,6 +84,13 @@ public final class RegisterFrame extends OpenDLXSimInternalFrame
         //config internal frame
         setLayout(new BorderLayout());
         add(scrollpane, BorderLayout.CENTER);
+        // new checkbox
+        checkBoxHex = new JCheckBox("values as hex");
+		checkBoxHex.setSelected(Preference.displayRegistersAsHex());
+		checkBoxHex.addItemListener(this);
+        JPanel controlPanel = new JPanel();
+		controlPanel.add(checkBoxHex);
+		add(controlPanel, BorderLayout.SOUTH);
         pack();
         setVisible(true);
     }
@@ -89,5 +101,12 @@ public final class RegisterFrame extends OpenDLXSimInternalFrame
         setVisible(false);
         dispose();
     }
+
+	@Override
+	public void itemStateChanged(ItemEvent e) {
+		Preference.pref.putBoolean(Preference.displayRegistersAsHex, checkBoxHex.isSelected());
+		update();
+		
+	}
 
 }


### PR DESCRIPTION
In MemoryFrame:
    New JCheckBox in the controlPanel of the MemoryFrame that toggles the corresponding preference 
     displayMemoryAsHex.
    controlPanel has a GridLayout, the reload-Button and the checkbox are in separate panels so that 
    they're centered in their cell of the grid while maintaining their normal size.
In RegisterFrame:
     New controlPanel with a JCheckBox in the RegisterFrame that toggles the corresponding preference 
     displayRegistersAsHex.
     The checkbox is in a panel so it's centered.
