### PR TITLE
fixed bug in CommandSaveAs

### DIFF
--- a/src/riscVivid/gui/command/userLevel/CommandSaveAs.java
+++ b/src/riscVivid/gui/command/userLevel/CommandSaveAs.java
@@ -42,13 +42,12 @@ public class CommandSaveAs implements Command
             File loadedFile = new File(mf.getLoadedCodeFilePath());
             //if there's no valid file currently loaded, 
             // set the loaded file to the chosen one
+            CommandSave.save(saveFile);
             if (!loadedFile.exists()) {
             	mf.setLoadedCodeFilePath(saveFile.getAbsolutePath());
-            	new CommandSave().execute();
-            } else if (loadedFile.equals(saveFile)){
-            	new CommandSave().execute();
-            } else {
-                CommandSave.save(saveFile);
+            	mf.setEditorSavedState();
+            } else if (loadedFile.equals(saveFile)) {
+            	mf.setEditorSavedState();
             }
         }
     }

--- a/src/riscVivid/gui/internalframes/concreteframes/MemoryFrame.java
+++ b/src/riscVivid/gui/internalframes/concreteframes/MemoryFrame.java
@@ -240,7 +240,7 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
     @Override
     public void setFont(Font f) {
     	super.setFont(f);
-    	for (Component c : new Component[] { addrLabel, addrInput, rowLabel, rowInput, reload})
+    	for (Component c : new Component[] { addrLabel, addrInput, rowLabel, rowInput, reload, checkBoxHex})
     		if (c != null)
     			c.setFont(f);
 

--- a/src/riscVivid/gui/internalframes/concreteframes/RegisterFrame.java
+++ b/src/riscVivid/gui/internalframes/concreteframes/RegisterFrame.java
@@ -105,6 +105,8 @@ public final class RegisterFrame extends OpenDLXSimInternalFrame implements Item
     @Override
     public void setFont(Font f) {
     	super.setFont(f);
+    	if (checkBoxHex != null)
+    		checkBoxHex.setFont(f);
     	if (registerTable != null) {
 	    	registerTable.setFont(f);
 	    	registerTable.getTableHeader().setFont(f);


### PR DESCRIPTION
fixed bug in CommandSaveAs that wouldn't allow to create a new file

changed the fonts of the checkboxes of the MemoryFrame and RegisterFrame in the setFont()-function, so that when the fontsize is changed, the fontsize of the checkboxes will change aswell