### PR TITLE
Warning if cycle count is exceeded

### DIFF
--- a/src/riscVivid/gui/command/systemLevel/CommandSimulatorFinishedInfo.java
+++ b/src/riscVivid/gui/command/systemLevel/CommandSimulatorFinishedInfo.java
@@ -22,6 +22,7 @@ package riscVivid.gui.command.systemLevel;
 
 import javax.swing.JOptionPane;
 
+import riscVivid.RiscVividSimulator;
 import riscVivid.gui.MainFrame;
 import riscVivid.gui.command.Command;
 
@@ -33,7 +34,19 @@ public class CommandSimulatorFinishedInfo implements Command
     public void execute()
     {
         MainFrame mf =MainFrame.getInstance();
-        JOptionPane.showMessageDialog(mf, "Simulator finished");
+        RiscVividSimulator sim = mf.getOpenDLXSim();
+
+        if (sim != null && sim.getCurrentCycle() >= sim.getSimCycles()) {
+        	JOptionPane.showMessageDialog(mf, "The Simulator has reached its maximum cycle count.\n" +
+        		"This could indicate that the program is stuck in an infinite loop " +
+        		"or has not been terminated correctly.",
+        		"Simulator finished: Maximum cycle count exceeded",
+        		JOptionPane.WARNING_MESSAGE);
+        	
+        			
+        } else {
+        	JOptionPane.showMessageDialog(mf, "Simulator finished");
+        }
     }
 
 }

--- a/src/riscVivid/gui/internalframes/FrameConfiguration.java
+++ b/src/riscVivid/gui/internalframes/FrameConfiguration.java
@@ -33,6 +33,8 @@ public class FrameConfiguration
     private String sizeXPreferenceKey = "sizex";
     private String sizeYPreferenceKey = "sizey";
     private String isVisiblePreferenceKey = "isvisible";
+    private String zOrderPreferenceKey = "zorder";
+    private String iconizedPreferenceKey = "iconized";
 
     public FrameConfiguration(JInternalFrame jif)
     {
@@ -47,6 +49,10 @@ public class FrameConfiguration
         pref.putInt(frameTitle + sizeXPreferenceKey, jif.getSize().width);
         pref.putInt(frameTitle + sizeYPreferenceKey, jif.getSize().height);
         pref.putBoolean(frameTitle + isVisiblePreferenceKey, jif.isVisible());
+        pref.putBoolean(frameTitle + iconizedPreferenceKey, jif.isIcon());
+        if (jif.getParent() != null)
+        	pref.putInt(frameTitle + zOrderPreferenceKey,
+        			jif.getParent().getComponentZOrder(jif));
     }
 
     public void loadFrameConfiguration()
@@ -56,9 +62,13 @@ public class FrameConfiguration
                 pref.getInt(frameTitle + posYPreferenceKey, jif.getY()),
                 pref.getInt(frameTitle + sizeXPreferenceKey, jif.getWidth()),
                 pref.getInt(frameTitle + sizeYPreferenceKey, jif.getHeight()));
+        if (jif.getParent() != null)
+        	jif.getParent().setComponentZOrder(jif,
+        			pref.getInt(frameTitle + zOrderPreferenceKey, 0));
 
         try
         {
+        	jif.setIcon(pref.getBoolean(frameTitle + iconizedPreferenceKey,  false));
             jif.setVisible(pref.getBoolean(jif.getTitle() + isVisiblePreferenceKey, true));
         }
         catch (Exception e)
@@ -67,4 +77,5 @@ public class FrameConfiguration
             e.printStackTrace();
         }
     }
+    
 }


### PR DESCRIPTION
in CommandSimulatorFinishedInfo.java:
- check if max cycle count has been reached and print a warning, otherwise finish normally

in FrameConfiguration.java:
- The z order of the frames is now saved aswell and restored in loadFrameConfiguration()
- Whether an InternalFrame was iconized is also saved and restored