### PR TITLE
Slight tweaks

### DIFF
--- a/src/riscVivid/asm/DLXAssembler.java
+++ b/src/riscVivid/asm/DLXAssembler.java
@@ -62,7 +62,7 @@ public class DLXAssembler implements AssemblerInterface {
 		parser.resolve(unresolvedInstructions, globalLabels, memory);
 		Integer entryPoint = globalLabels.get("main");
 		if (entryPoint != null)
-			memory.setEntyPoint(entryPoint);
+			memory.setEntryPoint(entryPoint);
 		else
 			throw new AssemblerException("no entry point 'main' found!\nPlease specify '.global main' and 'main:'.");
 		return memory;

--- a/src/riscVivid/asm/MemoryBuffer.java
+++ b/src/riscVivid/asm/MemoryBuffer.java
@@ -99,7 +99,7 @@ public class MemoryBuffer {
 	 * 
 	 * @param entryPoint
 	 */
-	public void setEntyPoint(int entryPoint) {
+	public void setEntryPoint(int entryPoint) {
 		if (entryPoint < 0)
 			entryPoint = 0;
 		this.entryPoint = entryPoint;

--- a/src/riscVivid/asm/parser/Parser.java
+++ b/src/riscVivid/asm/parser/Parser.java
@@ -36,6 +36,7 @@ import riscVivid.asm.tokenizer.Token;
 import riscVivid.asm.tokenizer.TokenType;
 import riscVivid.asm.tokenizer.Tokenizer;
 import riscVivid.asm.tokenizer.TokenizerException;
+import riscVivid.gui.internalframes.util.ValueInput;
 
 public class Parser {
 	private static final String INCOMPLETE_DIRECTIVE = "incomplete directive";
@@ -104,7 +105,7 @@ public class Parser {
 		globalLabels_ = globalLabels;
 		memory_ = memory;
 		for (UnresolvedInstruction instr : unresolvedInstructions_) {
-			if (instr.inTextSegement)
+			if (instr.inTextSegment)
 				segmentPointer_ = textPointer_;
 			else
 				segmentPointer_ = dataPointer_;
@@ -758,7 +759,7 @@ public class Parser {
 			return;
 		} else if (tokens.length == 2) {
 			try {
-				int value = Integer.decode(tokens[1].getString());
+				int value = ValueInput.getValueSilent(tokens[1].getString());
 				if (value < 0)
 					throw new ParserException(NUMBER_NEGATIVE, tokens[1]);
 				dataPointer_.set(value);
@@ -822,7 +823,7 @@ public class Parser {
 		try {
 			i = 1;
 			do {
-				int value = Integer.decode(tokens[i++].getString());
+				int value = ValueInput.getValueSilent(tokens[i++].getString());
 				segmentPointer_.add(value);
 			} while (i < tokens.length && tokens[i++].getString().equals(","));
 		} catch (ArrayIndexOutOfBoundsException ex) {
@@ -869,7 +870,7 @@ public class Parser {
 		try {
 			i = 1;
 			do {
-				int value = Integer.decode(tokens[i++].getString());
+				int value = ValueInput.getValueSilent(tokens[i++].getString());
 				memory_.writeWord(segmentPointer_.get(), value);
 				segmentPointer_.add(4);
 				memory_.setDataEnd(segmentPointer_.get());

--- a/src/riscVivid/asm/parser/UnresolvedInstruction.java
+++ b/src/riscVivid/asm/parser/UnresolvedInstruction.java
@@ -25,12 +25,12 @@ import riscVivid.asm.tokenizer.Token;
 public class UnresolvedInstruction {
 	public Token[] tokens;
 	public int position;
-	public boolean inTextSegement;
+	public boolean inTextSegment;
 
 	public UnresolvedInstruction(Token[] tokens, int position,
-			boolean inTextSegement) {
+			boolean inTextSegment) {
 		this.tokens = tokens;
 		this.position = position;
-		this.inTextSegement = inTextSegement;
+		this.inTextSegment = inTextSegment;
 	}
 }

--- a/src/riscVivid/gui/command/userLevel/CommandChangeFontSize.java
+++ b/src/riscVivid/gui/command/userLevel/CommandChangeFontSize.java
@@ -49,12 +49,18 @@ public class CommandChangeFontSize implements Command {
 	private static void setMenuBarFontSize(MainFrame mf, int fontSize) {
 		for (int i = 0; i < mf.getJMenuBar().getMenuCount(); ++i) {
 			JMenu menu = mf.getJMenuBar().getMenu(i);
-			Font newFont = menu.getFont().deriveFont((float)fontSize);
-			menu.setFont(newFont);
-			for (int itemIdx = 0; itemIdx < menu.getItemCount(); ++itemIdx) {
-				JMenuItem item = menu.getItem(itemIdx);
-				if (item != null)
-					item.setFont(newFont);
+			setMenuFontSize(menu, fontSize);
+		}
+	}
+	private static void setMenuFontSize(JMenu menu, int fontSize) {
+		Font newFont = menu.getFont().deriveFont((float)fontSize);
+		menu.setFont(newFont);
+		for (int itemIdx = 0; itemIdx < menu.getItemCount(); ++itemIdx) {
+			JMenuItem item = menu.getItem(itemIdx);
+			if (item instanceof JMenu){
+			    setMenuFontSize((JMenu)item, fontSize);
+			} else if (item != null) {
+				item.setFont(newFont);
 			}
 		}
 	}

--- a/src/riscVivid/gui/internalframes/concreteframes/MemoryFrame.java
+++ b/src/riscVivid/gui/internalframes/concreteframes/MemoryFrame.java
@@ -235,6 +235,7 @@ public final class MemoryFrame extends OpenDLXSimInternalFrame implements Action
                 JOptionPane.showMessageDialog(this, "for input only hex (0x..) " +
                         "address, decimal address or label (e.g. \"main\") allowed");
         }
+        memoryTable.scrollRectToVisible(memoryTable.getCellRect(0, 0, false));
     }
 
     @Override


### PR DESCRIPTION
made MemoryFrame scroll to the top after updating,
made CommandChangeFontSize also change the fontsize of submenus and submenus of submenus.
Parser uses ValueInput.getValueSilent instead of Integer.decode as it can also parse large (unsigned) Hex-numbers like 0xFFFFFFFF
fixed some spelling errors