### PR TITLE
Simulator now restarts when it is finished and a run command is executed

### DIFF
--- a/src/riscVivid/RiscVividSimulator.java
+++ b/src/riscVivid/RiscVividSimulator.java
@@ -76,7 +76,7 @@ public class RiscVividSimulator
     private boolean caught_break = false;
     private int clock_cycle;
     private int sim_cycles;
-    private boolean finished;
+    private boolean finished = false;
 
     /**
      * @param args

--- a/src/riscVivid/gui/MainFrame.java
+++ b/src/riscVivid/gui/MainFrame.java
@@ -72,7 +72,6 @@ public class MainFrame extends JFrame implements ActionListener, ItemListener
     private UndoManager undoMgr;
     private EditorFrame editor;
     private JDesktopPane desktop;
-    private boolean updateAllowed = true;
     private int runSpeed = RUN_SPEED_DEFAULT;
     private boolean pause = false;
     private OpenDLXSimState state = OpenDLXSimState.IDLE;
@@ -218,16 +217,6 @@ public class MainFrame extends JFrame implements ActionListener, ItemListener
     public boolean isLazy()
     {
         return (state == OpenDLXSimState.IDLE);
-    }
-
-    public boolean isUpdateAllowed()
-    {
-        return updateAllowed;
-    }
-
-    public void setUpdateAllowed(boolean updateAllowed)
-    {
-        this.updateAllowed = updateAllowed;
     }
 
     public void addInternalFrame(OpenDLXSimInternalFrame mif)

--- a/src/riscVivid/gui/command/systemLevel/CommandResetSimulator.java
+++ b/src/riscVivid/gui/command/systemLevel/CommandResetSimulator.java
@@ -44,7 +44,6 @@ public class CommandResetSimulator implements Command
         try
         {
             mf.setOpenDLXSim(null);
-            mf.setUpdateAllowed(true);
             mf.setConfigFile(null);
             mf.setPause(false);
             mf.setRunSpeed(MainFrame.RUN_SPEED_DEFAULT);

--- a/src/riscVivid/gui/command/systemLevel/ThreadCommandRun.java
+++ b/src/riscVivid/gui/command/systemLevel/ThreadCommandRun.java
@@ -79,7 +79,6 @@ public class ThreadCommandRun implements Runnable
 
         if (sim.isFinished())
         { // if the current riscVivid has finished, dont allow any gui updates any more                
-            mf.setUpdateAllowed(false);
             new CommandSimulatorFinishedInfo().execute();
         }
     }

--- a/src/riscVivid/gui/command/systemLevel/ThreadCommandRunSlowly.java
+++ b/src/riscVivid/gui/command/systemLevel/ThreadCommandRunSlowly.java
@@ -93,7 +93,6 @@ public class ThreadCommandRunSlowly implements Runnable
         // if the current riscVivid has finished, dont allow any gui updates any more
         if (sim.isFinished())
         {
-            mf.setUpdateAllowed(false);
             new CommandSimulatorFinishedInfo().execute();
         }
     }

--- a/src/riscVivid/gui/command/userLevel/CommandDoCycle.java
+++ b/src/riscVivid/gui/command/userLevel/CommandDoCycle.java
@@ -41,8 +41,11 @@ public class CommandDoCycle implements Command
     public void execute()
     {
 
-        if (mf.isExecuting() && mf.isUpdateAllowed())
+        if (mf.isExecuting())
         {
+            if (mf.getOpenDLXSim().isFinished())
+                new CommandResetCurrentProgram(mf).execute();
+
             RiscVividSimulator openDLXSim = mf.getOpenDLXSim();
             try
             {
@@ -59,7 +62,6 @@ public class CommandDoCycle implements Command
             }
             else
             {
-                mf.setUpdateAllowed(false);
                 new CommandSimulatorFinishedInfo().execute();
             }
         }

--- a/src/riscVivid/gui/command/userLevel/CommandDoXCycles.java
+++ b/src/riscVivid/gui/command/userLevel/CommandDoXCycles.java
@@ -47,8 +47,11 @@ public class CommandDoXCycles implements Command
     @Override
     public void execute()
     {
-        if (mf.isExecuting() && mf.isUpdateAllowed())
+        if (mf.isExecuting())
         {
+            if (mf.getOpenDLXSim().isFinished())
+                new CommandResetCurrentProgram(mf).execute();
+
             try
             {
                 RiscVividSimulator openDLXSim = mf.getOpenDLXSim();
@@ -84,7 +87,6 @@ public class CommandDoXCycles implements Command
 
                     if (openDLXSim.isFinished())
                     { // if the current riscVivid has finished, dont allow any gui updates any more                
-                        mf.setUpdateAllowed(false);
                         new CommandSimulatorFinishedInfo().execute();
                     }
                 }

--- a/src/riscVivid/gui/command/userLevel/CommandRun.java
+++ b/src/riscVivid/gui/command/userLevel/CommandRun.java
@@ -38,8 +38,10 @@ public class CommandRun implements Command
     public void execute()
     {
         //check if the main frame is executing/riscVivid is loaded
-        if (mf.isExecuting() && mf.isUpdateAllowed())
+        if (mf.isExecuting())
         {
+            if (mf.getOpenDLXSim().isFinished())
+                new CommandResetCurrentProgram(mf).execute();
             new Thread(new ThreadCommandRun(mf)).start();
         }
     }

--- a/src/riscVivid/gui/command/userLevel/CommandRunSlowly.java
+++ b/src/riscVivid/gui/command/userLevel/CommandRunSlowly.java
@@ -37,9 +37,11 @@ public class CommandRunSlowly implements Command
 
     @Override
     public void execute()
-    { //check if state is executing and check if the current riscVivid has finished (when it has finished ->updates are no longer allowed)
-        if (mf.isExecuting() && mf.isUpdateAllowed())
+    { //check if state is executing and check if the current riscVivid has finished
+        if (mf.isExecuting())
         {
+            if (mf.getOpenDLXSim().isFinished())
+                new CommandResetCurrentProgram(mf).execute();
             new Thread(new ThreadCommandRunSlowly(mf)).start();
             new Player(mf);
         }

--- a/src/riscVivid/gui/command/userLevel/CommandRunToAddressX.java
+++ b/src/riscVivid/gui/command/userLevel/CommandRunToAddressX.java
@@ -51,8 +51,10 @@ public class CommandRunToAddressX implements Command
     @Override
     public void execute()
     {
-        if (mf.isExecuting() && mf.isUpdateAllowed())
+        if (mf.isExecuting())
         {
+            if (mf.getOpenDLXSim().isFinished())
+                new CommandResetCurrentProgram(mf).execute();
             try
             {
                 RiscVividSimulator openDLXSim = mf.getOpenDLXSim();
@@ -83,7 +85,6 @@ public class CommandRunToAddressX implements Command
 
                     if (openDLXSim.isFinished())
                     { // if the current riscVivid has finished, dont allow any gui updates any more
-                        mf.setUpdateAllowed(false);
                         new CommandSimulatorFinishedInfo().execute();
                     }
                 }


### PR DESCRIPTION
When the program is finished, the simulator still stops so the user can inspect the results, but as soon as the user triggers a new run (e.g. by pressing F5), the program runs again from the start. This means that the user doesn't have to restart the program (e.g. by pressing F4) bevor he can run the program again.

Removed the unnecessary setUpdateAllowed() and isUpdateAllowed() functions from MainFrame, as the output of isUpdateAllowed equals !RiscVividSimulator.isFinished()